### PR TITLE
Remove unneeded streams from Theme YAML

### DIFF
--- a/purity.yaml
+++ b/purity.yaml
@@ -2,10 +2,3 @@ enabled: true
 layout: 0
 style: 0
 menu: 0
-
-streams:
-  scheme:
-    theme:
-      type: ReadOnlyStream
-      paths:
-        - user/themes/purity


### PR DESCRIPTION
These lines were in Antimatter and other themes, but they are useless now and break multisite
